### PR TITLE
Provide the option to use utf-8 as the default encoding.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ page_unavailable_html  (empty)            The full path to a file containing HTM
 privacy_mode           True               Enable or disable "private browsing mode" on the webkit widget.
 user_agent             (qt5 default)      Overrides the default user agent string.
 user_css               (empty)            Sets a default CSS file applied to all pages viewed. Option accepts any URL supported by QT, i.e: "file://etc/wcg.css" or "http://example.com/style.css".
-use_utf8_as_default    False              Sets the system's default encoding to UTF-8
+default_encoding       "utf-8"            The default encoding for the system to use.
 proxy_server           (empty)            Sets the proxy server string for HTTP proxy.  Takes the form "host:port", or just "host" if you want to use the default port of 8080.
 quit_button_mode       reset              Just like timeout_mode, only this is the action taken when the quit button is pressed (same options)
 quit_button_text       "I'm &Finished"    Text to display on the quit/reset button.  Can include an accelerator indicator (&).

--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,7 @@ page_unavailable_html  (empty)            The full path to a file containing HTM
 privacy_mode           True               Enable or disable "private browsing mode" on the webkit widget.
 user_agent             (qt5 default)      Overrides the default user agent string.
 user_css               (empty)            Sets a default CSS file applied to all pages viewed. Option accepts any URL supported by QT, i.e: "file://etc/wcg.css" or "http://example.com/style.css".
+use_utf8_as_default    False              Sets the system's default encoding to UTF-8
 proxy_server           (empty)            Sets the proxy server string for HTTP proxy.  Takes the form "host:port", or just "host" if you want to use the default port of 8080.
 quit_button_mode       reset              Just like timeout_mode, only this is the action taken when the quit button is pressed (same options)
 quit_button_text       "I'm &Finished"    Text to display on the quit/reset button.  Can include an accelerator indicator (&).

--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,7 @@ force_js_confirm       "ask"              If set to "accept" or "deny", will ove
 suppress_alerts        False              If True, blocks JavaScript popup alerts from appearing, or shows them when False.
 allow_printing         False              Enable printing of web pages from the context menu or toolbar.
 print_settings         (empty)            Specify default printer settings, see below.
+default_encoding       "utf-8"            The default encoding for the system to use.
 default_password       (empty)            default password to send when pages request authentication
 default_user           (empty)            default username to send when pages request authentication
 enable_diagnostic      False              Enable the display of diagnostic information when Ctrl-Alt-? is hit.
@@ -105,7 +106,6 @@ page_unavailable_html  (empty)            The full path to a file containing HTM
 privacy_mode           True               Enable or disable "private browsing mode" on the webkit widget.
 user_agent             (qt5 default)      Overrides the default user agent string.
 user_css               (empty)            Sets a default CSS file applied to all pages viewed. Option accepts any URL supported by QT, i.e: "file://etc/wcg.css" or "http://example.com/style.css".
-default_encoding       "utf-8"            The default encoding for the system to use.
 proxy_server           (empty)            Sets the proxy server string for HTTP proxy.  Takes the form "host:port", or just "host" if you want to use the default port of 8080.
 quit_button_mode       reset              Just like timeout_mode, only this is the action taken when the quit button is pressed (same options)
 quit_button_text       "I'm &Finished"    Text to display on the quit/reset button.  Can include an accelerator indicator (&).

--- a/browser.py
+++ b/browser.py
@@ -207,6 +207,7 @@ CONFIG_OPTIONS = {
                                "values": ["reset", "close", "screensaver"]},
     "user_agent":             {"default": None, "type": str},
     "user_css":               {"default": None, "type": str},
+    "use_utf8_as_default":    {"default": False, "type": bool},
     "whitelist":              {"default": None},  # don't check type here
     "window_size":            {"default": None},  # don't check type
     "zoom_factor":            {"default": 1.0, "type": float}
@@ -344,6 +345,13 @@ class MainWindow(QMainWindow):
                 tip=''
             )
             self.addAction(self.diagnostic_action)
+
+        # Set the default encoding to utf-8
+        if (self.config.get("use_utf8_as_default")):
+            reload(sys)
+            sys.setdefaultencoding('utf-8')
+        else:
+            print("Not using UTF-8")
 
         self.build_ui()
 

--- a/browser.py
+++ b/browser.py
@@ -350,8 +350,6 @@ class MainWindow(QMainWindow):
         if (self.config.get("use_utf8_as_default")):
             reload(sys)
             sys.setdefaultencoding('utf-8')
-        else:
-            print("Not using UTF-8")
 
         self.build_ui()
 

--- a/browser.py
+++ b/browser.py
@@ -172,6 +172,7 @@ CONFIG_OPTIONS = {
     "allow_printing":         {"default": False, "type": bool},
     "bookmarks":              {"default": {}, "type": dict},
     "content_handlers":       {"default": {}, "type": dict},
+    "default_encoding":       {"default": "utf-8", "type": str},
     "default_password":       {"default": None, "type": str},
     "default_user":           {"default": None, "type": str},
     "enable_diagnostic":      {"default": False, "type": bool},
@@ -207,7 +208,6 @@ CONFIG_OPTIONS = {
                                "values": ["reset", "close", "screensaver"]},
     "user_agent":             {"default": None, "type": str},
     "user_css":               {"default": None, "type": str},
-    "use_utf8_as_default":    {"default": False, "type": bool},
     "whitelist":              {"default": None},  # don't check type here
     "window_size":            {"default": None},  # don't check type
     "zoom_factor":            {"default": 1.0, "type": float}
@@ -346,10 +346,9 @@ class MainWindow(QMainWindow):
             )
             self.addAction(self.diagnostic_action)
 
-        # Set the default encoding to utf-8
-        if (self.config.get("use_utf8_as_default")):
-            reload(sys)
-            sys.setdefaultencoding('utf-8')
+        # Set the default encoding
+        reload(sys)
+        sys.setdefaultencoding(self.config.get("default_encoding"))
 
         self.build_ui()
 

--- a/wcgbrowser.yaml
+++ b/wcgbrowser.yaml
@@ -257,9 +257,7 @@ content_handlers:
   "application/pdf": "acroread"
   "application/vnd.oasis.opendocument.text": "libreoffice"
 
-# Use UTF-8 as default encoding
-# If use_utf8_as_default is set to True, the system's default encoding will be set to UTF-8.
-# This is so that special characters can be entered without issue.
-# Default: false
+# Set the default encoding for the sytem to use.
+# Default: "utf-8"
 
-use_utf8_as_default: False
+default_encoding: "utf-8"

--- a/wcgbrowser.yaml
+++ b/wcgbrowser.yaml
@@ -256,3 +256,10 @@ bookmarks:
 content_handlers:
   "application/pdf": "acroread"
   "application/vnd.oasis.opendocument.text": "libreoffice"
+
+# Use UTF-8 as default encoding
+# If use_utf8_as_default is set to True, the system's default encoding will be set to UTF-8.
+# This is so that special characters can be entered without issue.
+# Default: false
+
+use_utf8_as_default: False


### PR DESCRIPTION
When entering special characters such as `å` into the browser, an error is thrown:

```
Traceback (most recent call last):
  File "browser.py", line 676, in _finished
    .format(status=status, headers=headers, url=url)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe5' in position 141: ordinal not in range(128)
Traceback (most recent call last):
  File "browser.py", line 934, in onLinkClick
    debug("Request URL: {}".format(url.toString()))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe5' in position 57: ordinal not in range(128)
Traceback (most recent call last):
  File "browser.py", line 676, in _finished
    .format(status=status, headers=headers, url=url)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe5' in position 57: ordinal not in range(128)
```

The addition of the option takes care of this. Made optional as utf-8 may not be the desired encoding.